### PR TITLE
Adding additional check for TMUX when setting foreground/background/cursor color

### DIFF
--- a/templates/shell/dark.sh.erb
+++ b/templates/shell/dark.sh.erb
@@ -80,7 +80,7 @@ printf $printf_template 20 $color20
 printf $printf_template 21 $color21
 
 # foreground / background / cursor color
-if [ -n "$ITERM_SESSION_ID" ]; then
+if [ -n "$ITERM_SESSION_ID" ] && [ -z "$TMUX" ]; then
   # iTerm2 proprietary escape codes
   printf $printf_template_custom Pg <%= @base["05"]["hex"] %> # forground
   printf $printf_template_custom Ph <%= @base["00"]["hex"] %> # background

--- a/templates/shell/light.sh.erb
+++ b/templates/shell/light.sh.erb
@@ -80,7 +80,7 @@ printf $printf_template 20 $color20
 printf $printf_template 21 $color21
 
 # foreground / background / cursor color
-if [ -n "$ITERM_SESSION_ID" ]; then
+if [ -n "$ITERM_SESSION_ID" ] && [ -z "$TMUX" ]; then
   # iTerm2 proprietary escape codes
   printf $printf_template_custom Pg <%= @base["02"]["hex"] %> # forground
   printf $printf_template_custom Ph <%= @base["07"]["hex"] %> # background


### PR DESCRIPTION
If I open zsh from within tmux, I can hear a bell, and it's because it's trying to run iterm proprietary scape codes. I've added a check for TMUX and in case is present, use normal scape codes.